### PR TITLE
Add copilot-swe-agent[bot] to cla.yml

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -26,6 +26,7 @@ configuration:
          - learn-build-service-test[bot]
          - learn-build-service-ppe[bot]
          - learn-build-service-prod[bot]
+         - copilot-swe-agent[bot]
          - CBL-Mariner-Bot
          - pbicvbot
          - acomghbot


### PR DESCRIPTION
This pull request updates the `policies/cla.yml` file to include a new bot in the configuration section.

* [`policies/cla.yml`](diffhunk://#diff-eba4db74f3326ace7a077f48fcf6a9df30d334397b111a625f66e4a8c557e5f2R29): Added `copilot-swe-agent[bot]` to the list of authorized bots in the `configuration` section.